### PR TITLE
Update cdk-pipeline-stack.ts

### DIFF
--- a/cdk/lib/Airdrop/cdk-pipeline-stack.ts
+++ b/cdk/lib/Airdrop/cdk-pipeline-stack.ts
@@ -60,6 +60,6 @@ export class CDKPipelineStack extends Stack {
     super(scope, id, props);
 
     createPipeline(this, appEnv.ropsten);
-    createPipeline(this, appEnv.mainnet);
+    // createPipeline(this, appEnv.mainnet);
   }
 }


### PR DESCRIPTION
Disabling mainnet release from cdk, which is causing code pipeline failure. 