### PR TITLE
Moving to "server" on `next.config.js` because build is failing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,5 +7,5 @@ module.exports = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  target: "serverless",
+  target: "server",
 };


### PR DESCRIPTION
Moving to "server" on `next.config.js` because build is failing